### PR TITLE
Improve modal layout and transitions

### DIFF
--- a/src/ImageModal.jsx
+++ b/src/ImageModal.jsx
@@ -2,23 +2,27 @@ import React, { useState, useEffect } from 'react';
 
 const ImageModal = ({ images = [], onClose, initialIndex = 0 }) => {
   const [activeIndex, setActiveIndex] = useState(initialIndex);
-  const [rotating, setRotating] = useState(false);
+  const [fading, setFading] = useState(false);
 
   const changeIndex = (idx) => {
     if (idx === activeIndex) return;
-    setRotating(true);
-    setActiveIndex(idx);
+    setFading(true);
+    // start fade out then change image
+    setTimeout(() => setActiveIndex(idx), 150);
   };
 
   useEffect(() => {
-    if (rotating) {
-      const timer = setTimeout(() => setRotating(false), 300);
+    if (fading) {
+      const timer = setTimeout(() => setFading(false), 300);
       return () => clearTimeout(timer);
     }
-  }, [rotating]);
+  }, [activeIndex, fading]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
+      onClick={onClose}
+    >
       <div
         className="relative bg-gray-900 border border-cyan-500/50 rounded-xl p-4"
         onClick={(e) => e.stopPropagation()}
@@ -29,19 +33,29 @@ const ImageModal = ({ images = [], onClose, initialIndex = 0 }) => {
         >
           &times;
         </button>
-        <div className="flex items-center justify-center gap-4">
-          {images.map((img, idx) => (
-            <img
-              key={idx}
-              src={img}
-              onClick={() => changeIndex(idx)}
-              className={`transition-all duration-300 rounded-lg cursor-pointer ${
-                idx === activeIndex
-                  ? `w-96 ${rotating ? 'rotate-180' : ''}`
-                  : 'w-24 opacity-50 grayscale hover:opacity-80'
-              }`}
-            />
-          ))}
+        <div className="flex flex-col items-center">
+          <img
+            src={images[activeIndex]}
+            className={`w-[50vw] md:w-[40vw] max-h-[80vh] object-contain rounded-lg transition-opacity duration-300 ${
+              fading ? 'opacity-0' : 'opacity-100'
+            }`}
+          />
+          {images.length > 1 && (
+            <div className="mt-4 flex gap-2">
+              {images.map((img, idx) => (
+                <img
+                  key={idx}
+                  src={img}
+                  onClick={() => changeIndex(idx)}
+                  className={`h-16 w-16 object-cover rounded cursor-pointer transition-opacity duration-300 ${
+                    idx === activeIndex
+                      ? 'border-2 border-cyan-500'
+                      : 'opacity-60 hover:opacity-80'
+                  }`}
+                />
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- refine `ImageModal` to center the main image and remove spin animation
- add fading transition when changing images
- show thumbnails only when multiple images exist

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68499d2997188321808aaad26905f1f6