### PR TITLE
Add image overlay and modal fade

### DIFF
--- a/src/ImageModal.jsx
+++ b/src/ImageModal.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 const ImageModal = ({ images = [], onClose, initialIndex = 0 }) => {
   const [activeIndex, setActiveIndex] = useState(initialIndex);
   const [fading, setFading] = useState(false);
+  const [closing, setClosing] = useState(false);
 
   const changeIndex = (idx) => {
     if (idx === activeIndex) return;
@@ -18,10 +19,21 @@ const ImageModal = ({ images = [], onClose, initialIndex = 0 }) => {
     }
   }, [activeIndex, fading]);
 
+  useEffect(() => {
+    if (closing) {
+      const timer = setTimeout(() => {
+        onClose();
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [closing, onClose]);
+
+  const handleClose = () => setClosing(true);
+
   return (
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70"
-      onClick={onClose}
+      className={`fixed inset-0 z-50 flex items-center justify-center bg-black/70 transition-opacity duration-300 ${closing ? 'opacity-0' : 'opacity-100'}`}
+      onClick={handleClose}
     >
       <div
         className="relative bg-gray-900 border border-cyan-500/50 rounded-xl p-4"
@@ -29,7 +41,7 @@ const ImageModal = ({ images = [], onClose, initialIndex = 0 }) => {
       >
         <button
           className="absolute top-2 right-2 text-gray-300 hover:text-white"
-          onClick={onClose}
+          onClick={handleClose}
         >
           &times;
         </button>

--- a/src/Portfolio.jsx
+++ b/src/Portfolio.jsx
@@ -137,9 +137,16 @@ const Portfolio = () => {
                   <img
                     src={project.image}
                     alt={project.title}
-                    className="w-full h-48 object-cover cursor-pointer"
-                    onClick={() => openModal(project)}
+                    className="w-full h-48 object-cover transition-all duration-300 group-hover:brightness-50"
                   />
+                  <button
+                    onClick={() => openModal(project)}
+                    className="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/0 group-hover:bg-black/60 transition-all duration-300 text-white font-semibold"
+                  >
+                    <span className="relative after:absolute after:left-0 after:right-0 after:-bottom-1 after:h-0.5 after:bg-white after:scale-x-0 after:origin-left after:transition-transform after:duration-300 group-hover:after:scale-x-100">
+                      Ver mais
+                    </span>
+                  </button>
                 </div>
                 <div className="p-6 flex flex-col flex-1">
                   <h3 className="text-xl font-semibold mb-2">{project.title}</h3>


### PR DESCRIPTION
## Summary
- Darken project card images on hover and show "Ver mais" overlay
- Animate underline on the overlay text
- Smooth fade-out when closing image modal

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a00cdaa6883219d1e32190f93ae52